### PR TITLE
Added missing , in author's has many relationship

### DIFF
--- a/domain.lisp
+++ b/domain.lisp
@@ -12,9 +12,8 @@
 (define-resource author ()
   :class (s-prefix "schema:Author")
   :properties `((:name :string ,(s-prefix "schema:name")))
-  :has-many `((book :via (s-prefix "schema:author")
+  :has-many `((book :via ,(s-prefix "schema:author")
                     :inverse t
                     :as "books"))
   :resource-base (s-url "http://mu.semte.ch/services/github/madnificent/book-service/authors/")
   :on-path "authors")
- 


### PR DESCRIPTION
A comma is missing from the author's has many relationship. This caused an exception with mu-cl-resources:

```
resource_1    | #<THREAD "main thread" RUNNING {1002D57183}>:
resource_1    |   There is no applicable method for the generic function
resource_1    |     #<STANDARD-GENERIC-FUNCTION SPARQL-ESCAPE (10)>
resource_1    |   when called with arguments
resource_1    |     ((S-PREFIX "schema:author")).
```